### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,8 +19,12 @@ To create your own widget set:
   ```grunt rename --name=mynewname --email=email@mail.com --author="Author Name"```
   
   *mynewname* must be **lower** case and with no spaces.
+
+  If grunt is not availible, install grunt globally:
+  
+  ```npm install -g grunt-cli```
  
-- rename directory from *ioBroker.vis-template* to *ioBroker.vis-mynewname*
+- rename directory from *ioBroker.vis-template* to *iobroker.vis-mynewname*
 
 - to use this template you should copy it into *iobroker/node_modules* directory
   call ```iobroker visdebug mynewname``` to enable debugging and upload widget to "vis". (This works only from V0.7.15 of js-controller)


### PR DESCRIPTION
1. Install grunt, if not available
2. Adapter with name ioBroker.vis.mynewname (captital letter B) isn't found by vis. If the name ob the adapter is changed to iobroker.vis-mynewname, it will work
